### PR TITLE
Hotfix-1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biotablero-backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Backend for 'Biotablero' project",
   "main": "src/app.js",
   "scripts": {

--- a/src/service/strategy.js
+++ b/src/service/strategy.js
@@ -19,7 +19,7 @@ module.exports = strategyPersistence => ({
       error.code = 400;
       throw error;
     }
-    const geometry = await strategyPersistence.findGeoByBiomeSubzoneEA(bId, sId, envAuthorityId);
+    let geometry = await strategyPersistence.findGeoByBiomeSubzoneEA(bId, sId, envAuthorityId);
     const listStrategies = await strategyPersistence.findByBiomeSubzoneEA(bId, sId, envAuthorityId);
     const groupedStrategies = groupObjects(['id_strategy'], listStrategies);
 
@@ -31,6 +31,8 @@ module.exports = strategyPersistence => ({
         strategy_name: groupedStrategies[key][0].strategy.strategy,
       };
     });
+
+    geometry = geometry.features === null ? null : geometry;
 
     return { strategies, geometry };
   },


### PR DESCRIPTION
Return null geometry when there are no strategies for a biome-zsh-car combination.

Handles: [Compensaciones: Blank screen when selecting a combination of Subzone and CAR](https://github.com/PEM-Humboldt/biotablero/issues/101)